### PR TITLE
Undo breaking bugfix and honour suggested secret length

### DIFF
--- a/main.js
+++ b/main.js
@@ -360,13 +360,13 @@ app.get('/store/secret', function (req, res) {
 	}
 
 	if (req.container.secret) {
-        	res.send(new Buffer(req.container.secret).toString('base64'));
+		res.send(new Buffer(req.container.secret).toString('base64'));
 		return;
 	}
 
 	// NOTE: Actually should be 8 / log2(62), but 4 / 3 is close enough.
-        req.container.secret = randomstring.generate(randStrOpts);
-        res.send(new Buffer(req.container.secret).toString('base64'));
+	req.container.secret = randomstring.generate(randStrOpts);
+	res.send(new Buffer(req.container.secret).toString('base64'));
 
 });
 

--- a/main.js
+++ b/main.js
@@ -358,12 +358,13 @@ app.get('/store/secret', function (req, res) {
 	}
 
 	if (req.container.secret) {
-		res.send(req.container.secret);
+        	res.send(new Buffer(req.container.secret).toString('base64'));
 		return;
 	}
 
-        req.container.secret = new Buffer(randomstring.generate({ length: 128 })).toString('base64');
-        res.send(req.container.secret);
+	// NOTE: Actually should be 8 / log2(62), but 4 / 3 is close enough.
+        req.container.secret = randomstring.generate({ length: Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH) });
+        res.send(new Buffer(req.container.secret).toString('base64'));
 
 });
 

--- a/main.js
+++ b/main.js
@@ -337,6 +337,8 @@ app.post('/token', function(req, res){
 
 /**********************************************************/
 
+let randStrOpts = { length: Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH) };
+
 app.get('/store/secret', function (req, res) {
 	if (!req.container) {
 		// NOTE: This can also happen if the CM never uploaded store key
@@ -363,7 +365,7 @@ app.get('/store/secret', function (req, res) {
 	}
 
 	// NOTE: Actually should be 8 / log2(62), but 4 / 3 is close enough.
-        req.container.secret = randomstring.generate({ length: Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH) });
+        req.container.secret = randomstring.generate(randStrOpts);
         res.send(new Buffer(req.container.secret).toString('base64'));
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/test/stores.js
+++ b/test/stores.js
@@ -2,6 +2,7 @@ process.env.CM_KEY = 'chrC9e52tR5ljd+02Shg6khojHNUpAhaqAplQ1jFgCw='
 
 var supertest = require('supertest')(require('../main.js'));
 var assert = require('assert');
+var macaroons = require('macaroons.js');
 
 describe('Test store endpoints', function() {
 	var storeKey = '8MDlgBNXfmklmQVTrJxfIwAjo8j5nIrE8aeFVIdn6Kg=';
@@ -107,7 +108,7 @@ describe('Test store endpoints', function() {
 			.send(testStore)
 			.expect(function (res) {
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === 128;
+				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});
@@ -120,7 +121,7 @@ describe('Test store endpoints', function() {
 			.send(testStore)
 			.expect(function (res) {
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === 128;
+				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -111,7 +111,7 @@ describe('Test token endpoint', function() {
 			.expect(function (res) {
 				storeSecret = res.text;
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === 128;
+				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});


### PR DESCRIPTION
My original "bug fix" wasn't actually a bug fix. Also instead of an arbitrary 128 for length, this will make it so that `macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH` (bytes) is used.

The alphanumeric character space is 62 characters, the base64 character space is 64 characters (with `+` and `/`. With alphanumeric, we need ceil((32 * 8) / log2(64)) = 43 characters for 32 bytes (44 with padding), and for alphanumeric, ceil((32 x 8) / log2(62)) = 43 characters for 32 bytes. So because they're so close, the secret length will be the suggested number of bytes times 4 / 3 (like base64).

As @jptmoore [mentioned](https://github.com/me-box/core-arbiter/pull/30#issuecomment-318039396), now that the secrets have safe characters, we can completely make away with the base64 encoding/decoding step. This would be API-breaking however and would require updates to all stores.