### PR TITLE
Remove base64 encoding of store secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ NB: Container arbiter key (see developer guide) MUST be provided as per section 
 
 ###### Success
 
-  - 200: [Base64-encoded secret for verifying container macaroons]
+  - 200: [Alphanumeric secret for verifying container macaroons]
 
 ###### Error
 
@@ -195,7 +195,6 @@ NB: Container arbiter key (see developer guide) MUST be provided as per section 
   - 401: Invalid API key (see description above)
   - 500: Container type unknown by arbiter
   - 403: Container type [type] cannot use arbiter token minting capabilities as it is not a store type
-  - 500: Unable to register container (secret generation)
 
 
 ### Container-facing

--- a/main.js
+++ b/main.js
@@ -337,6 +337,7 @@ app.post('/token', function(req, res){
 
 /**********************************************************/
 
+// NOTE: Actually should be 8 / log2(62), but 4 / 3 is close enough.
 let randStrOpts = { length: Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH) };
 
 app.get('/store/secret', function (req, res) {
@@ -360,13 +361,12 @@ app.get('/store/secret', function (req, res) {
 	}
 
 	if (req.container.secret) {
-		res.send(new Buffer(req.container.secret).toString('base64'));
+		res.send(req.container.secret);
 		return;
 	}
 
-	// NOTE: Actually should be 8 / log2(62), but 4 / 3 is close enough.
 	req.container.secret = randomstring.generate(randStrOpts);
-	res.send(new Buffer(req.container.secret).toString('base64'));
+	res.send(req.container.secret);
 
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "databox-arbiter",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "The Databox Docker container that manages the flow of data",
   "config": {
     "registry": "registry.iotdatabox.com"

--- a/test/stores.js
+++ b/test/stores.js
@@ -108,7 +108,7 @@ describe('Test store endpoints', function() {
 			.send(testStore)
 			.expect(function (res) {
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
+				res.text = res.text.length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});
@@ -121,7 +121,7 @@ describe('Test store endpoints', function() {
 			.send(testStore)
 			.expect(function (res) {
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
+				res.text = res.text.length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -111,7 +111,7 @@ describe('Test token endpoint', function() {
 			.expect(function (res) {
 				storeSecret = res.text;
 				// TODO: Error handling
-				res.text = Buffer.from(res.text, 'base64').length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
+				res.text = res.text.length === Math.ceil((4 / 3) * macaroons.MacaroonsConstants.MACAROON_SUGGESTED_SECRET_LENGTH);
 			})
 			.expect(200, true, done);
 	});


### PR DESCRIPTION
It turns out that the mystery incompatibility in handling macaroons between Node.js and OCaml from #30, was that the macaroons.js can accept secrets as either utf-8 strings or Buffers, with Buffers being more efficient. The arbiter was minting macaroons with Buffers, which results in distinct signatures than with strings, _even if it's the same bytes_ as the [lib's code shows](https://github.com/nitram509/macaroons.js/blob/master/src/main/ts/MacaroonsBuilder.ts#L168).

Since ocaml-macaroons deals with strings, the past changes switched to string secrets. This inadvertently broke store-json. @Toshbrown remedied this by moving that also to strings in https://github.com/me-box/store-json/pull/6. And since we're modifying that, we took the opportunity to close #32 too. With that change, all is well in the world, and the new ocaml store also doesn't need to base64 decode anything.